### PR TITLE
fix .#packages.aarch64-linux.htpc-1-sdImage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,101 @@
+{
+  "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1723685519,
+        "narHash": "sha256-GkXQIoZmW2zCPp1YFtAYGg/xHNyFH/Mgm79lcs81rq0=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "276a0d055a720691912c6a34abb724e395c8e38a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1723399884,
+        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1721549352,
+        "narHash": "sha256-nlXJa8RSOX0kykrIYW33ukoHYq+FOSNztHLLgqKwOp8=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "dbce39ea8664820ba9037caaf1e2fad365ed6b4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nixos-hardware": {
+      "locked": {
+        "lastModified": 1723310128,
+        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723703277,
+        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "disko": "disko",
+        "home-manager": "home-manager",
+        "nix-flatpak": "nix-flatpak",
+        "nixos-hardware": "nixos-hardware",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,26 @@
       url = "github:nix-community/disko";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixpkgs.follows = "nixpkgs";
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware";
     };
     nix-flatpak.url = "github:gmodena/nix-flatpak";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
-    }
+    };
   };
 
-  outputs = { nixpkgs, disko, nixos-generators, home-manager, nix-flatpak, ... }:
+  outputs = { self, nixpkgs, disko, home-manager, nix-flatpak, nixos-hardware, ... }:
+  let
+    eachSystem = f:
+      nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"] (system:
+        f {
+          inherit system;
+          pkgs = nixpkgs.legacyPackages.${system};
+        }
+      );
+  in
   {
     nixosConfigurations = {
 
@@ -30,15 +38,57 @@
         ];
       };
 
-    };
-
-    packages.x86_64-linux = {
-      htpc-1 = nixos-generators.nixosGenerate {
-        system = "armv7l-linux";
+      # https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_4
+      "htpc-1" = nixpkgs.lib.nixosSystem {
         modules = [
-          ./common/users.nix
+          # TODO: move this to a configuration.nix file
+          ({ pkgs, ... }: {
+            imports = [
+              home-manager.nixosModules.home-manager
+              nixos-hardware.nixosModules.raspberry-pi-4
+              ./htpc/user.nix
+              "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
+            ];
+
+            nixpkgs.hostPlatform = "aarch64-linux";
+
+            # Fix missing modules
+            # https://github.com/NixOS/nixpkgs/issues/154163
+            nixpkgs.overlays = [
+              (final: super: {
+                makeModulesClosure = x:
+                  super.makeModulesClosure (x // { allowMissing = true; });
+              })
+            ];
+
+            hardware = {
+              raspberry-pi."4".apply-overlays-dtmerge.enable = true;
+              deviceTree = {
+                enable = true;
+                filter = "*rpi-4-*.dtb";
+              };
+            };
+
+            console.enable = false;
+
+            environment.systemPackages = with pkgs; [
+              libraspberrypi
+              raspberrypi-eeprom
+            ];
+
+            system.stateVersion = "24.05";
+          })
         ];
       };
+
     };
+
+    packages = eachSystem ({ system, ... }: {
+      htpc-1-sdImage = (self.nixosConfigurations.htpc-1.extendModules {
+        # Configure cross-compilation
+        modules = [ { nixpkgs.buildPlatform.system = system; } ];
+        # Expose the sdImage brought in by the sd-image-aarch64.nix profile
+      }).config.system.build.sdImage;
+    });
   };
 }

--- a/htpc/user.nix
+++ b/htpc/user.nix
@@ -9,7 +9,7 @@ in
   };
 
   home-manager.users."${username}" = {
-    home.stateVersion = stateVersion;
+    home.stateVersion = config.system.stateVersion;
     home.enableNixpkgsReleaseCheck = false;
     xsession.windowManager.i3 = {
         enable = true;


### PR DESCRIPTION
* Replace the nixos-generators wrapper with direct usage to simplify the
  reasoning a bit.
* Split the machine configuration from the sd-card generation, to make
  things a bit simpler as well.
* Add nixos-hardware for the Rasperri Pi 4 hardware configuration.
* Add necessary workarounds.
